### PR TITLE
Update tests to work from prison in python environment if available

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2019 Beto Dealmeida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,6 +1,9 @@
 import unittest
 
-from .context import prison
+try:
+    import prison
+except ImportError:
+    from .context import prison
 
 
 class TestDecoder(unittest.TestCase):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,6 +1,9 @@
 import unittest
 
-from .context import prison
+try:
+    import prison
+except ImportError:
+    from .context import prison
 
 
 class TestEncoder(unittest.TestCase):


### PR DESCRIPTION
This merge makes the test work as expected when `prison` has been installed in a python environment, as opposed to being available via a local checkout of the GitHub repo.  This is needed to perform the tests after installing `prison` in a `conda` environment.

I also add the MIT license file.