### PR TITLE
Fix, infinite loop exception

### DIFF
--- a/prison/decoder.py
+++ b/prison/decoder.py
@@ -19,6 +19,8 @@ class Parser(object):
     This parser supports RISON, RISON-A and RISON-O.
     """
     def parse(self, string, format=str):
+        if string == "(":
+            raise ParserException("unmatched '('")
         if format in [list, 'A']:
             self.string = "!({0})".format(string)
         elif format in [dict, 'O']:
@@ -81,8 +83,6 @@ class Parser(object):
                 self.index -= 1
             n = self.read_value()
             ar.append(n)
-
-        return ar
 
     def parse_bang(self):
         s = self.string
@@ -200,7 +200,6 @@ class Parser(object):
     def next(self):
         s = self.string
         i = self.index
-        c = None
 
         while 1:
             if i == len(s):

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -31,6 +31,10 @@ class TestDecoder(unittest.TestCase):
         self.assertEqual(prison.loads('!t'), True)
         self.assertEqual(prison.loads('!f'), False)
 
+    def test_invalid(self):
+        with self.assertRaises(prison.decoder.ParserException):
+            prison.loads('(')
+
     def test_none(self):
         self.assertEqual(prison.loads('!n'), None)
 


### PR DESCRIPTION
Happens when decoding a single open parenthesis

``` python
import prison
prison.loads('(')
```

```
6, in parse_open_paren
    k = self.read_value()
  File "/home/dpgaspar/workarea/preset/v_superset/lib/python3.6/site-packages/prison/decoder.py", line 45, in read_value
    return self.parse_open_paren()
  File "/home/dpgaspar/workarea/preset/v_superset/lib/python3.6/site-packages/prison/decoder.py", line 106, in parse_open_paren
    c = self.next()
  File "/home/dpgaspar/workarea/preset/v_superset/lib/python3.6/site-packages/prison/decoder.py", line 206, in next
    if i == len(s):
RecursionError: maximum recursion depth exceeded in comparison
```

Related issue:
https://github.com/dpgaspar/Flask-AppBuilder/issues/1177
