### PR TITLE
fix: percent doesn't need to be quoted

### DIFF
--- a/prison/constants.py
+++ b/prison/constants.py
@@ -3,7 +3,7 @@ import re
 
 WHITESPACE = ''
 
-IDCHAR_PUNCTUATION = '_-./~'
+IDCHAR_PUNCTUATION = '_-./~%'
 
 NOT_IDCHAR = ''.join([c for c in (chr(i) for i in range(127))
                       if not (c.isalnum()

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -26,6 +26,9 @@ class TestDecoder(unittest.TestCase):
         self.assertEqual(prison.loads("(a:0)"), {
             'a': 0
         })
+        self.assertEqual(prison.loads("(a:%)"), {
+            'a': '%'
+        })
 
     def test_bool(self):
         self.assertEqual(prison.loads('!t'), True)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -26,6 +26,9 @@ class TestEncoder(unittest.TestCase):
         self.assertEqual("(a:0)", prison.dumps({
             'a': 0
         }))
+        self.assertEqual("(a:%)", prison.dumps({
+            'a': '%'
+        }))
 
     def test_bool(self):
         self.assertEqual('!t', prison.dumps(True))
@@ -59,4 +62,3 @@ class TestEncoder(unittest.TestCase):
         self.assertEqual("'user@domain.com'", prison.dumps('user@domain.com'))
         self.assertEqual("'US $10'", prison.dumps('US $10'))
         self.assertEqual("'can!'t'", prison.dumps("can't"))
-


### PR DESCRIPTION
Looking at the [rison playground](https://rison.io/) it seems like we shouldn't add quotes to the percent symbol.

![Screen Shot 2021-08-26 at 10 36 34 AM](https://user-images.githubusercontent.com/1534870/131009614-23f888e6-ec89-4790-8f01-3351f9349f02.png)

The Javascript [rison-node](https://www.npmjs.com/package/rison-node) has the same behavior:

![Screen Shot 2021-08-26 at 10 38 18 AM](https://user-images.githubusercontent.com/1534870/131009858-d831cc86-18c3-472f-b2b9-03912aee88a7.png)

So does [rison](https://www.npmjs.com/package/rison):

![Screen Shot 2021-08-26 at 10 39 59 AM](https://user-images.githubusercontent.com/1534870/131010056-b8762c35-be96-4f72-b6dd-1eb11b7971cd.png)

This PR makes it compatible:

```python
>>> prison.dumps(dict(a='%'))
'(a:%)'
>>> prison.loads('(a:%)')
{'a': '%'}
```